### PR TITLE
Add per-thread locking to Redis saver

### DIFF
--- a/langgraph/checkpoint/redis/aio.py
+++ b/langgraph/checkpoint/redis/aio.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+from collections import defaultdict
 from contextlib import asynccontextmanager
 from types import TracebackType
 from typing import (
@@ -82,6 +83,8 @@ class AsyncRedisSaver(
             ttl=ttl,
         )
         self.loop = asyncio.get_running_loop()
+        # Per-thread locks for async operations
+        self._thread_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     def configure_client(
         self,
@@ -113,6 +116,16 @@ class AsyncRedisSaver(
         self.checkpoint_writes_index = AsyncSearchIndex.from_dict(
             self.SCHEMAS[2], redis_client=self._redis
         )
+
+    @asynccontextmanager
+    async def athread_lock(self, thread_id: str) -> AsyncIterator[None]:
+        """Async context manager to serialize access per thread."""
+        lock = self._thread_locks[thread_id]
+        await lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
 
     async def __aenter__(self) -> AsyncRedisSaver:
         """Async context manager enter."""

--- a/langgraph/checkpoint/redis/aio.py
+++ b/langgraph/checkpoint/redis/aio.py
@@ -75,12 +75,16 @@ class AsyncRedisSaver(
         redis_client: Optional[Union[AsyncRedis, AsyncRedisCluster]] = None,
         connection_args: Optional[Dict[str, Any]] = None,
         ttl: Optional[Dict[str, Any]] = None,
+        lock_block: bool = True,
+        lock_timeout: float = 1.0,
     ) -> None:
         super().__init__(
             redis_url=redis_url,
             redis_client=redis_client,
             connection_args=connection_args,
             ttl=ttl,
+            lock_block=lock_block,
+            lock_timeout=lock_timeout,
         )
         self.loop = asyncio.get_running_loop()
         # Per-thread locks for async operations
@@ -118,14 +122,39 @@ class AsyncRedisSaver(
         )
 
     @asynccontextmanager
-    async def athread_lock(self, thread_id: str) -> AsyncIterator[None]:
+    async def athread_lock(
+        self,
+        thread_id: str,
+        *,
+        block: Optional[bool] = None,
+        timeout: Optional[float] = None,
+    ) -> AsyncIterator[None]:
         """Async context manager to serialize access per thread."""
         lock = self._thread_locks[thread_id]
-        await lock.acquire()
+        if block is None:
+            block = self.lock_block
+        if timeout is None:
+            timeout = self.lock_timeout
+        acquired = False
+        if block:
+            try:
+                await asyncio.wait_for(lock.acquire(), timeout=timeout)
+                acquired = True
+            except asyncio.TimeoutError:
+                acquired = False
+        else:
+            if not lock.locked():
+                lock.acquire()  # type: ignore[func-returns-value]
+                acquired = True
+        if not acquired:
+            raise TimeoutError(
+                f"Could not acquire lock for {thread_id} within {timeout}s"
+            )
         try:
             yield
         finally:
-            lock.release()
+            if acquired:
+                lock.release()
 
     async def __aenter__(self) -> AsyncRedisSaver:
         """Async context manager enter."""

--- a/langgraph/checkpoint/redis/base.py
+++ b/langgraph/checkpoint/redis/base.py
@@ -3,7 +3,10 @@ import binascii
 import json
 import random
 from abc import abstractmethod
-from typing import Any, Dict, Generic, List, Optional, Sequence, Tuple, cast
+from collections import defaultdict
+from contextlib import contextmanager
+from threading import Lock
+from typing import Any, Dict, Generic, Iterator, List, Optional, Sequence, Tuple, cast
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
@@ -122,6 +125,9 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
         # Store TTL configuration
         self.ttl_config = ttl
 
+        # Per-thread locks to serialize operations
+        self._thread_locks: dict[str, Lock] = defaultdict(Lock)
+
         self.configure_client(
             redis_url=redis_url,
             redis_client=redis_client,
@@ -148,6 +154,16 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
     ) -> None:
         """Configure the Redis client."""
         pass
+
+    @contextmanager
+    def thread_lock(self, thread_id: str) -> Iterator[None]:
+        """Context manager to serialize access per thread."""
+        lock = self._thread_locks[thread_id]
+        lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
 
     def set_client_info(self) -> None:
         """Set client info for Redis monitoring."""

--- a/langgraph/checkpoint/redis/base.py
+++ b/langgraph/checkpoint/redis/base.py
@@ -107,6 +107,8 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
         redis_client: Optional[RedisClientType] = None,
         connection_args: Optional[Dict[str, Any]] = None,
         ttl: Optional[Dict[str, Any]] = None,
+        lock_block: bool = True,
+        lock_timeout: float = 1.0,
     ) -> None:
         """Initialize Redis-backed checkpoint saver.
 
@@ -117,6 +119,8 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
             ttl: Optional TTL configuration dict with optional keys:
                 - default_ttl: TTL in minutes for all checkpoint keys
                 - refresh_on_read: Whether to refresh TTL on reads
+            lock_block: Whether lock acquisition should block by default
+            lock_timeout: Seconds to wait when acquiring a lock by default
         """
         super().__init__(serde=JsonPlusRedisSerializer())
         if redis_url is None and redis_client is None:
@@ -124,6 +128,9 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
 
         # Store TTL configuration
         self.ttl_config = ttl
+        # Default lock behaviour
+        self.lock_block = lock_block
+        self.lock_timeout = lock_timeout
 
         # Per-thread locks to serialize operations
         self._thread_locks: dict[str, Lock] = defaultdict(Lock)
@@ -156,14 +163,32 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
         pass
 
     @contextmanager
-    def thread_lock(self, thread_id: str) -> Iterator[None]:
+    def thread_lock(
+        self,
+        thread_id: str,
+        *,
+        block: Optional[bool] = None,
+        timeout: Optional[float] = None,
+    ) -> Iterator[None]:
         """Context manager to serialize access per thread."""
         lock = self._thread_locks[thread_id]
-        lock.acquire()
+        if block is None:
+            block = self.lock_block
+        if timeout is None:
+            timeout = self.lock_timeout
+        if block:
+            acquired = lock.acquire(timeout=timeout)
+        else:
+            acquired = lock.acquire(blocking=False)
+        if not acquired:
+            raise TimeoutError(
+                f"Could not acquire lock for {thread_id} within {timeout}s"
+            )
         try:
             yield
         finally:
-            lock.release()
+            if acquired:
+                lock.release()
 
     def set_client_info(self) -> None:
         """Set client info for Redis monitoring."""

--- a/tests/test_thread_lock.py
+++ b/tests/test_thread_lock.py
@@ -1,0 +1,38 @@
+import concurrent.futures
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import empty_checkpoint
+
+from langgraph.checkpoint.redis import RedisSaver
+
+
+def _increment(
+    checkpointer: RedisSaver, config: RunnableConfig, iterations: int
+) -> None:
+    for _ in range(iterations):
+        with checkpointer.thread_lock(config["configurable"]["thread_id"]):
+            tup = checkpointer.get_tuple(config)
+            cp = tup.checkpoint if tup else empty_checkpoint()
+            cp.setdefault("channel_values", {}).setdefault("count", 0)
+            cp["channel_values"]["count"] += 1
+            checkpointer.put(
+                config, cp, {}, {"count": str(cp["channel_values"]["count"])}
+            )
+
+
+@pytest.mark.skip("Requires running Redis container")
+def test_thread_lock_serialization(redis_url: str) -> None:
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        config: RunnableConfig = {"configurable": {"thread_id": "t"}}
+        saver.put(config, empty_checkpoint(), {}, {})
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(_increment, saver, config, 5) for _ in range(2)]
+            for f in futures:
+                f.result()
+
+        final = saver.get_tuple(config)
+        assert final is not None
+        assert final.checkpoint["channel_values"]["count"] == 10


### PR DESCRIPTION
## Summary
- serialize updates by tracking a lock for each thread_id in the saver
- expose `thread_lock`/`athread_lock` context managers
- add a concurrency test placeholder requiring Redis container

## Testing
- `make format`
- `make check` 
